### PR TITLE
Update workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
 
       - name: Install
-        if: ${{ steps.cache-modules.output.cache-hit != 'true' }}
+        if: ${{ steps.cache-modules.outputs.cache-hit != 'true' }}
         run: npm install
 
       - name: Lint, test & build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,22 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [18.x, 20.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node_modules
         id: cache-modules
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ matrix.node-version }}-${{ runner.OS }}-build-${{ hashFiles('package.json') }}
 
       - name: Install
-        if: steps.cache-modules.output.cache-hit != 'true'
+        if: ${{ steps.cache-modules.output.cache-hit != 'true' }}
         run: npm install
 
       - name: Lint, test & build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 env:
-  NODE_VERSION: 16.x
+  NODE_VERSION: 18.x
 
 jobs:
   bump-version:
@@ -14,16 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag-name: ${{ steps.bump.outputs.newTag }}
+    permissions:
+      contents: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
-          # This is a public_repo Github personal access token.
-          token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bump version
         id: bump
-        uses: phips28/gh-action-bump-version@v9.1.0
+        uses: phips28/gh-action-bump-version@v11.0.4
         with:
           tag-prefix: 'v'
           commit-message: '[CI/CD]: bump to {{version}}'
@@ -35,12 +36,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.bump-version.outputs.tag-name }}
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.bump-version.outputs.tag-name }}
 
@@ -51,12 +52,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ needs.bump-version.outputs.tag-name }}
 
       - name: Use node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag-name: ${{ steps.bump.outputs.newTag }}
-    permissions:
-      contents: write
 
     steps:
       - uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # This is a public_repo Github personal access token.
+          token: ${{ secrets.WORKFLOW_GITHUB_TOKEN }}
 
       - name: Bump version
         id: bump


### PR DESCRIPTION
Some issues are reported on the workflows:

- The workflows were executed on old Node versions. Solution is to only use Node version 18 and 20
- Old versions of actions were used. Solution is to use the latest versions

After installing VSCode Github Actions extension it appeared that the logic to cache node_modules was incorrect so that is now also fixed (and verified)
