### PR TITLE
use setImmediate instead of setTimeout

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -72,8 +72,8 @@ export class Logger {
     traceWrap<T extends (...args: any[]) => any>(name: string, func: T): T {
         const logger = this;
 
-        function maybeTraced(this: any) {
-            return logger.trace() ? traced.apply(this, arguments as any) : func.apply(this, arguments as any);
+        function maybeTraced(this: any, ...args: any[]) {
+            return logger.trace() ? traced.apply(this, args) : func.apply(this, args);
         }
 
         function traced(this: any, ...args: any[]) {

--- a/src/loghandler.ts
+++ b/src/loghandler.ts
@@ -65,7 +65,7 @@ export function forLogger(name: string | RegExp, handler: LogHandler): LogHandle
  * Wraps the given handler s.t. the handler is called asynchronously in a future tick.
  */
 export function async(handler: LogHandler): LogHandler {
-    return record => setTimeout(handler, 0, record);
+    return record => setImmediate(() => handler(record));
 }
 
 /**


### PR DESCRIPTION
Enhancement: Asynchronous Log Processing

This change introduces asynchronous log processing to improve performance, especially under high volume scenarios.